### PR TITLE
Shared string caching

### DIFF
--- a/lib/Spreadsheet/XLSX/Cell.rakumod
+++ b/lib/Spreadsheet/XLSX/Cell.rakumod
@@ -108,16 +108,8 @@ sub cell-from-xml(LibXML::Element $element) is export {
     }
 }
 
-#| Takes an XML node from shared strings and produces the correct kind of
-#| Cell object from it.
-sub shared-cell-from-xml(LibXML::Element $element) is export {
-    given $element.nodeName {
-        when 't' {
-            Spreadsheet::XLSX::Cell::Text.new(value => $element.string-value)
-        }
-        default {
-            die X::NYI.new(feature => "Excel shared cells of type '$_'");
-        }
-    }
+#| Takes a Str value from shared strings and produces a Cell object from it.
+sub shared-cell-from-xml(Str $val) is export {
+    Spreadsheet::XLSX::Cell::Text.new(value => $val)
 }
 

--- a/lib/Spreadsheet/XLSX/SharedStrings.rakumod
+++ b/lib/Spreadsheet/XLSX/SharedStrings.rakumod
@@ -30,6 +30,16 @@ class Spreadsheet::XLSX::SharedStrings does Positional {
                 when 't' {
                     $element.string-value
                 }
+                when 'r' {
+                    # TODO: Deep RichText handling.
+                    my $text;
+                    for $element.childNodes -> $elem {
+                        if $elem.nodeName eq 't' {
+                            $text ~= $elem.string-value;
+                        }
+                    }
+                    $text
+                }
                 default {
                     die X::NYI.new(feature => "Excel shared cells of type '$_'");
                 }


### PR DESCRIPTION
Add caching to shared strings. Accessing shared strings turned out to be a bottleneck in larger workbooks. Also adds very rudimentary rich text cell support. This implementation simply extracts the plaintext compontents and works with those.