### PR TITLE
Return Nil when there is no cell at a position

### DIFF
--- a/lib/Spreadsheet/XLSX/Worksheet.rakumod
+++ b/lib/Spreadsheet/XLSX/Worksheet.rakumod
@@ -129,7 +129,7 @@ class Spreadsheet::XLSX::Worksheet {
                     }
             }
 
-            return Spreadsheet::XLSX::Cell;
+            return Nil;
         }
 
         method !load-backing-rows {


### PR DESCRIPTION
This would make more sense than returning `Spreadsheet::XLSX::Cell` type object because in the latter case it causes a confusing error.

Kind of a fix for #8.