### PR TITLE
Fix loading of ODS/XLS spreadsheets #12

### DIFF
--- a/lib/Spreadsheet/XLSX/ContentTypes.rakumod
+++ b/lib/Spreadsheet/XLSX/ContentTypes.rakumod
@@ -30,7 +30,7 @@ class Spreadsheet::XLSX::ContentTypes {
             die X::Spreadsheet::XLSX::Format.new: message =>
                     'Content types did not start with tag Types';
         }
-        for $root.childNodes -> LibXML::Element $entry {
+        for $root.elements -> LibXML::Element $entry {
             if $entry.nodeName eq 'Default' {
                 @defaults.push: Default.new:
                         extension => self!get-attribute($entry, 'Extension'),

--- a/lib/Spreadsheet/XLSX/Relationships.rakumod
+++ b/lib/Spreadsheet/XLSX/Relationships.rakumod
@@ -40,7 +40,7 @@ class Spreadsheet::XLSX::Relationships {
             die X::Spreadsheet::XLSX::Format.new: message =>
                     'Relationships file did not start with tag Relationships';
         }
-        self.new: :$for, relationships => $root.childNodes.map: -> LibXML::Element $entry {
+        self.new: :$for, relationships => $root.elements.map: -> LibXML::Element $entry {
             Relationship.new:
                     :id(self!get-attribute($entry, 'Id')),
                     :type(self!get-attribute($entry, 'Type')),

--- a/lib/Spreadsheet/XLSX/Workbook.rakumod
+++ b/lib/Spreadsheet/XLSX/Workbook.rakumod
@@ -39,8 +39,8 @@ class Spreadsheet::XLSX::Workbook {
             die X::Spreadsheet::XLSX::Format.new: message =>
                     'Workbook file did not start with tag workbook';
         }
-        with $workbook.childNodes.list.first(*.name eq 'sheets') -> LibXML::Element $sheets-node {
-            my @worksheets = $sheets-node.childNodes.map: -> LibXML::Element $sheet-node {
+        with $workbook.elements.list.first(*.name eq 'sheets') -> LibXML::Element $sheets-node {
+            my @worksheets = $sheets-node.elements.map: -> LibXML::Element $sheet-node {
                 my $id := self!get-attribute($sheet-node, 'sheetId').Int;
                 my $name := self!get-attribute($sheet-node, 'name');
                 my $sheet-rel-id := self!get-attribute($sheet-node, 'r:id');
@@ -179,7 +179,7 @@ class Spreadsheet::XLSX::Workbook {
             # This will work out for sure, 'cus if it didn't we'd not have
             # successfully constructed this instance.
             my $workbook = $!backing.documentElement;
-            $workbook.childNodes.list.first(*.name eq 'sheets')
+            $workbook.elements.list.first(*.name eq 'sheets')
         }
         else {
             $!backing .= new: :version('1.0'), :enc('UTF-8');

--- a/lib/Spreadsheet/XLSX/Worksheet.rakumod
+++ b/lib/Spreadsheet/XLSX/Worksheet.rakumod
@@ -135,7 +135,7 @@ class Spreadsheet::XLSX::Worksheet {
         method !load-backing-rows {
             with $!backing {
                 unless @!backing-rows {
-                    $!backing.childNodes.map: -> LibXML::Element $backing-row {
+                    $!backing.elements.map: -> LibXML::Element $backing-row {
                         if $backing-row.nodeName eq 'row' {
                             my $row-str = get-attribute($backing-row, 'r');
                             @!backing-rows[$row-str.Int - 1] = $backing-row;
@@ -374,8 +374,8 @@ class Spreadsheet::XLSX::Worksheet {
         my @columns;
         with $!backing-path {
             my LibXML::Element $doc-root := self!get-backing-document().documentElement();
-            with $doc-root.childNodes.list.first(*.nodeName eq 'cols') -> LibXML::Element $cols {
-                for $cols.childNodes -> LibXML::Element $col {
+            with $doc-root.elements.list.first(*.nodeName eq 'cols') -> LibXML::Element $cols {
+                for $cols.elements -> LibXML::Element $col {
                     for get-attribute($col, 'min').Int .. get-attribute($col, 'max').Int {
                         @columns[$_ - 1] = Column.from-xml($col);
                     }
@@ -437,7 +437,7 @@ class Spreadsheet::XLSX::Worksheet {
         }
 
         # Update the sheet data.
-        my @node-list := $!backing.documentElement.childNodes.list;
+        my @node-list := $!backing.documentElement.elements.list;
         my LibXML::Element $sheetData = @node-list.first(*.name eq 'sheetData');
         with $sheetData {
             .sync-sheet-data-xml($sheetData, $!root.styles) with $!cells;


### PR DESCRIPTION
The basic problem seems to be that this workbook is peppered with blank nodes. Somehow `.childNodes -> my LibXML::Element $e {...}` hangs rather than throwing a typecheck error.

This PR does enough to get the sample spreadhseet attached to issue to open.