### PR TITLE
Alter the order of attributes in Styles

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -6,7 +6,7 @@
   "auth": "zef:jnthn",
   "depends": [
     "Libarchive",
-    "LibXML:ver<0.6.0+>"
+    "LibXML:ver<0.10.6+>"
   ],
   "build-depends": [],
   "test-depends": [],

--- a/lib/Spreadsheet/XLSX/Styles.rakumod
+++ b/lib/Spreadsheet/XLSX/Styles.rakumod
@@ -248,6 +248,13 @@ class Spreadsheet::XLSX::Styles does XMLRepresentation["styleSheet"] {
 
     class CellStyles is xml-sequence(<cellStyles>, CT_CellStyle) does XMLCounting { }
 
+    #| All number format records.
+    has NumberFormats:D $.number-formats is xml-elem .= new;
+
+    #| Every number format has an ID, but some IDs are allocated with
+    #| existing meanings. Thus, we track the maximum number of those.
+    has Int $!max-number-format-id = $!number-formats.map(*.id).max max 166;
+
     #| All font records in the styles.
     has Fonts:D $.fonts is xml-elem .= new(Font.new);
 
@@ -256,13 +263,6 @@ class Spreadsheet::XLSX::Styles does XMLRepresentation["styleSheet"] {
 
     #| All border records in the styles.
     has Borders:D $.borders is xml-elem .= new(Border.new);
-
-    #| All number format records.
-    has NumberFormats:D $.number-formats is xml-elem .= new;
-
-    #| Every number format has an ID, but some IDs are allocated with
-    #| existing meanings. Thus, we track the maximum number of those.
-    has Int $!max-number-format-id = $!number-formats.map(*.id).max max 166;
 
     #| All formatting records (referenced from cell formats).
     has Formats:D $.formatting-records is xml-elem<cellStyleXfs> .= new(Format.new);


### PR DESCRIPTION
In the schema of the stylesheet element
(https://schemas.liquid-technologies.com/officeopenxml/2006/?page=sml-styles_xsd.html) the stylesheet is defined as an xsd:sequence which means that a validating parser must consider the order of the elements in the document against the order the elements are defined in the schema.

It seems that there is some version of MS Excel on MacOS that does use a validating parser and will always insist on "repairing" the spreadsheet with the order of the elements as they are, it will open the file fine after that.  Passing the spreadsheet through e.g. LibreOffice (without complaint,) will also fix it.

So this moves the numFmts attribute as the first element of the stylesheet which is how it is in the schema. I don't think any other changes are required as `.^attributes(:local) ` appears to return them in the order they are defined in the class. The other attributes appear to be in the defined order.